### PR TITLE
bugfix: missing update of this.length

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ Pipeline.prototype._notEmpty = function () {
         }
     });
     this._streams.push(stream);
+    this.length = this._streams.length;
 };
 
 Pipeline.prototype.push = function (stream) {


### PR DESCRIPTION
This is a corner case. At least the bug helped me understand that a splicer sometimes adds its own passthrough.
